### PR TITLE
Divide token authenticatable

### DIFF
--- a/lib/simple_token_authentication/acts_as_token_authenticatable.rb
+++ b/lib/simple_token_authentication/acts_as_token_authenticatable.rb
@@ -1,88 +1,19 @@
 require 'active_support/concern'
-require 'simple_token_authentication/token_generator'
+require 'simple_token_authentication/token_authenticatable'
 
 module SimpleTokenAuthentication
   module ActsAsTokenAuthenticatable
-    extend ::ActiveSupport::Concern
 
-    # Please see https://gist.github.com/josevalim/fb706b1e933ef01e4fb6
-    # before editing this file, the discussion is very interesting.
+    extend ActiveSupport::Concern
 
-    included do
-      private :generate_authentication_token
-      private :token_suitable?
-      private :token_generator
-      private :invalidate_cached_auth
-
-      attr_accessor :plain_authentication_token, :persisted_authentication_token
-    end
-
-    def authentication_token= token
-
-      self.plain_authentication_token = token
-
-      if token.nil?
-        self.persisted_authentication_token = nil
-      elsif  SimpleTokenAuthentication.persist_token_as_plain?
-        # Persist the plain token
-        self.persisted_authentication_token = token
-      elsif SimpleTokenAuthentication.persist_token_as_digest?
-        # Persist the digest of the token
-        self.persisted_authentication_token = Devise::Encryptor.digest(SimpleTokenAuthentication, token)
-      end
-
-      invalidate_cached_auth
-
-      # Check for existence of an write_attribute method, to allow specs to operate without a true persistence layer
-      if defined?(write_attribute)
-        write_attribute(:authentication_token, self.persisted_authentication_token)
-      end
-    end
-
-    def authentication_token
-      if defined?(read_attribute)
-        read_attribute :authentication_token
-      else
-        persisted_authentication_token
-      end
-    end
-
-    # Set an authentication token if missing
-    #
-    # Because it is intended to be used as a filter,
-    # this method is -and should be kept- idempotent.
-    def ensure_authentication_token
-      if authentication_token.blank?
-        self.authentication_token = generate_authentication_token(token_generator)
-      end
-    end
-
-    def generate_authentication_token(token_generator)
-      loop do
-        token = token_generator.generate_token
-        break token if token_suitable?(token)
-      end
-    end
-
-    def token_suitable?(token)
-      # Alway true if digest is persisted, since we can't check for duplicates
-      return true if SimpleTokenAuthentication.persist_token_as_digest?
-      self.class.where(authentication_token: token).count == 0
-    end
-
-    def token_generator
-      TokenGenerator.instance
-    end
-
-    # Invalidate an existing cache item
-    def invalidate_cached_auth
-      cache = SimpleTokenAuthentication.cache_provider
-      cache.invalidate_auth(self.id) if cache
-    end
+    # This module ensures that no TokenAuthenticatableHandler behaviour
+    # is added before the class actually `acts_as_token_authenticatable`
+    # otherwise we inject unnecessary methods into ORMs.
+    # This follows the pattern of ActsAsTokenAuthenticationHandler
 
     module ClassMethods
       def acts_as_token_authenticatable(options = {})
-        before_save :ensure_authentication_token
+        include SimpleTokenAuthentication::TokenAuthenticatable
       end
     end
   end

--- a/lib/simple_token_authentication/acts_as_token_authenticatable.rb
+++ b/lib/simple_token_authentication/acts_as_token_authenticatable.rb
@@ -29,9 +29,9 @@ module SimpleTokenAuthentication
       elsif SimpleTokenAuthentication.persist_token_as_digest?
         # Persist the digest of the token
         self.persisted_authentication_token = Devise::Encryptor.digest(SimpleTokenAuthentication, token)
-
-        invalidate_cached_auth
       end
+
+      invalidate_cached_auth
 
       # Check for existence of an write_attribute method, to allow specs to operate without a true persistence layer
       if defined?(write_attribute)

--- a/lib/simple_token_authentication/acts_as_token_authenticatable.rb
+++ b/lib/simple_token_authentication/acts_as_token_authenticatable.rb
@@ -74,8 +74,7 @@ module SimpleTokenAuthentication
       TokenGenerator.instance
     end
 
-    # Invalidate an existing cache item by setting its value to 'new'
-    # This works
+    # Invalidate an existing cache item
     def invalidate_cached_auth
       cache = SimpleTokenAuthentication.cache_provider
       cache.invalidate_auth(self.id) if cache

--- a/lib/simple_token_authentication/token_authenticatable.rb
+++ b/lib/simple_token_authentication/token_authenticatable.rb
@@ -1,0 +1,86 @@
+require 'active_support/concern'
+require 'simple_token_authentication/token_generator'
+
+module SimpleTokenAuthentication
+  module TokenAuthenticatable
+    extend ::ActiveSupport::Concern
+
+    # Please see https://gist.github.com/josevalim/fb706b1e933ef01e4fb6
+    # before editing this file, the discussion is very interesting.
+
+    included do
+      private :generate_authentication_token
+      private :token_suitable?
+      private :token_generator
+      private :invalidate_cached_auth
+
+      before_save :ensure_authentication_token
+
+      attr_accessor :plain_authentication_token, :persisted_authentication_token
+    end
+
+    def authentication_token= token
+
+      self.plain_authentication_token = token
+
+      if token.nil?
+        self.persisted_authentication_token = nil
+      elsif  SimpleTokenAuthentication.persist_token_as_plain?
+        # Persist the plain token
+        self.persisted_authentication_token = token
+      elsif SimpleTokenAuthentication.persist_token_as_digest?
+        # Persist the digest of the token
+        self.persisted_authentication_token = Devise::Encryptor.digest(SimpleTokenAuthentication, token)
+      end
+
+      invalidate_cached_auth
+
+      # Check for existence of an write_attribute method, to allow specs to operate without a true persistence layer
+      if defined?(write_attribute)
+        write_attribute(:authentication_token, self.persisted_authentication_token)
+      end
+    end
+
+    def authentication_token
+      if defined?(read_attribute)
+        read_attribute :authentication_token
+      else
+        persisted_authentication_token
+      end
+    end
+
+    # Set an authentication token if missing
+    #
+    # Because it is intended to be used as a filter,
+    # this method is -and should be kept- idempotent.
+    def ensure_authentication_token
+      if authentication_token.blank?
+        self.authentication_token = generate_authentication_token(token_generator)
+      end
+    end
+
+    def generate_authentication_token(token_generator)
+      loop do
+        token = token_generator.generate_token
+        break token if token_suitable?(token)
+      end
+    end
+
+    def token_suitable?(token)
+      # Alway true if digest is persisted, since we can't check for duplicates
+      return true if SimpleTokenAuthentication.persist_token_as_digest?
+      self.class.where(authentication_token: token).count == 0
+    end
+
+    def token_generator
+      TokenGenerator.instance
+    end
+
+    # Invalidate an existing cache item
+    def invalidate_cached_auth
+      cache = SimpleTokenAuthentication.cache_provider
+      cache.invalidate_auth(self.id) if cache
+    end
+
+  end
+end

--- a/spec/lib/simple_token_authentication/acts_as_token_authenticatable_spec.rb
+++ b/spec/lib/simple_token_authentication/acts_as_token_authenticatable_spec.rb
@@ -57,6 +57,8 @@ describe 'A token authenticatable class (or one of its children)' do
     it 'responds to :ensure_authentication_token', protected: true do
       @subjects.map!{ |subject| subject.new }
       @subjects.each do |subject|
+        allow(subject.class).to receive(:before_save)
+        subject.class.acts_as_token_authenticatable
         expect(subject).to respond_to :ensure_authentication_token
       end
     end
@@ -92,6 +94,9 @@ describe 'A token authenticatable class (or one of its children)' do
         SimpleTokenAuthentication.persist_token_as = :plain
 
         @subjects.each do |subject|
+          allow(subject.class).to receive(:before_save)
+          subject.class.acts_as_token_authenticatable
+
           subject.ensure_authentication_token
 
           expect(subject.authentication_token).not_to eq 'ExampleTok3n'
@@ -106,6 +111,9 @@ describe 'A token authenticatable class (or one of its children)' do
         SimpleTokenAuthentication.persist_token_as = :digest
 
         @subjects.each do |subject|
+          allow(subject.class).to receive(:before_save)
+          subject.class.acts_as_token_authenticatable
+
           subject.ensure_authentication_token
           expect(subject.plain_authentication_token).to eq 'Dist1nCt-Tok3N'
           expect(subject.persisted_authentication_token).not_to be nil
@@ -117,6 +125,9 @@ describe 'A token authenticatable class (or one of its children)' do
         SimpleTokenAuthentication.persist_token_as = :digest
 
         @subjects.each do |subject|
+          allow(subject.class).to receive(:before_save)
+          subject.class.acts_as_token_authenticatable
+
           subject.ensure_authentication_token
           hashed_token = subject.persisted_authentication_token
           plain_token = subject.plain_authentication_token
@@ -130,6 +141,9 @@ describe 'A token authenticatable class (or one of its children)' do
         SimpleTokenAuthentication.persist_token_as = :digest
         token_comparator = SimpleTokenAuthentication::TokenComparator.instance
         @subjects.each do |subject|
+          allow(subject.class).to receive(:before_save)
+          subject.class.acts_as_token_authenticatable
+          
           subject.ensure_authentication_token
           hashed_token = subject.persisted_authentication_token
           plain_token = subject.plain_authentication_token

--- a/spec/lib/simple_token_authentication/test_caching_spec.rb
+++ b/spec/lib/simple_token_authentication/test_caching_spec.rb
@@ -64,7 +64,11 @@ describe 'SimpleTokenAuthentication::Caches::RailsCacheProvider' do
       SimpleTokenAuthentication.persist_token_as = :digest
 
       @subject = Class.new do
+        def self.before_save _
+        end
         include SimpleTokenAuthentication::ActsAsTokenAuthenticatable
+        acts_as_token_authenticatable
+
         attr_accessor :email, :id
 
         def initialize(opt={})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ require 'action_controller'
 require 'active_record'
 require 'mongoid'
 require 'active_support'
-require 'byebug'
 require 'simple_token_authentication'
 
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f; puts f }


### PR DESCRIPTION
Changes to prevent unnecessary methods being injected into ActiveRecord::Base, as discussed in issue #345. Make `acts_as_token_authenticatable` include a new `TokenAuthenticable` when called, rather than pushing everything into the base class.